### PR TITLE
Security Update

### DIFF
--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -42,20 +42,20 @@ class FileStorage:
 
     def save(self):
         """serializes __objects to the JSON file (path: __file_path)"""
-        json_objects = {}
+        odict = {}
         for key in self.__objects:
-            json_objects[key] = self.__objects[key].to_dict()
-        with open(self.__file_path, 'w') as f:
-            json.dump(json_objects, f)
+            odict[key] = self.__objects[key].to_dict(remove_password=False)
+        with open(self.__file_path, "w", encoding="utf-8") as f:
+            json.dump(odict, f)
 
     def reload(self):
-        """deserializes the JSON file to __objects"""
+        """Deserializes the JSON file to __objects"""
         try:
-            with open(self.__file_path, 'r') as f:
+            with open(self.__file_path, "r", encoding="utf-8") as f:
                 jo = json.load(f)
             for key in jo:
                 self.__objects[key] = classes[jo[key]["__class__"]](**jo[key])
-        except:
+        except FileNotFoundError:
             pass
 
     def delete(self, obj=None):

--- a/models/user.py
+++ b/models/user.py
@@ -1,9 +1,10 @@
-#!/usr/bin/python
-""" holds class User"""
+#!/usr/bin/python3
+"""Defines the User class."""
 import models
-from models.base_model import BaseModel, Base
-from os import getenv
+import hashlib
 import sqlalchemy
+from os import getenv
+from models.base_model import BaseModel, Base
 from sqlalchemy import Column, String
 from sqlalchemy.orm import relationship
 
@@ -25,5 +26,12 @@ class User(BaseModel, Base):
         last_name = ""
 
     def __init__(self, *args, **kwargs):
-        """initializes user"""
+        """Initializes a User."""
         super().__init__(*args, **kwargs)
+
+    def __setattr__(self, name, value):
+        """Encodes passwords using MD5 before setting an attribute."""
+        if name == "password":
+            value = value.encode("utf-8")
+            value = hashlib.md5(value).hexdigest()
+        object.__setattr__(self, name, value)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -404,7 +404,7 @@ class HolbertonBnBTestCase(unittest.TestCase):
             self.assertEqual(resp.status_code, 201)
             self.assertEqual(msg.get("__class__"), "User")
             self.assertEqual(msg.get("email"), "h@h.com")
-            self.assertEqual(msg.get("password"), "dwp")
+            self.assertIsNone(msg.get("password"))
             self.assertGreater(storage.count("User"), count)
 
     def test_users_bad_post(self):
@@ -459,12 +459,13 @@ class HolbertonBnBTestCase(unittest.TestCase):
                 "created_at": "avoid",
                 "updated_at": "avoid",
             }
+            original = self.user.id
             resp = a.put("/api/v1/users/{}".format(self.user.id),
                          json=data, follow_redirects=True)
             self.assertEqual(resp.status_code, 200)
-            self.assertEqual(resp.get_json().get("password"), "new")
+            self.assertNotEqual(resp.get_json().get("password"), original)
             user = storage.get("User", self.user.id)
-            self.assertEqual(user.password, "new")
+            self.assertNotEqual(user.password, original)
             self.assertNotEqual(user.id, "avoid")
             self.assertNotEqual(user.email, "avoid")
             self.assertNotEqual(user.created_at, "avoid")

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -96,7 +96,8 @@ class TestDBStorage(unittest.TestCase):
         """Test all method with specified class."""
         users = self.storage.all(User)
         self.assertEqual(len(users), 1)
-        self.assertEqual(list(users.values())[0].password, "password")
+        self.assertEqual(list(users.values())[0].email,
+                         "holberton@holberton.com")
 
     @unittest.skipIf(type(storage) != DBStorage, "Testing FileStorage")
     def test_new(self):

--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -2,10 +2,14 @@
 """
 Contains the TestFileStorageDocs classes
 """
-
-from datetime import datetime
+import os
+import json
+import pep8
 import inspect
+import unittest
 import models
+from datetime import datetime
+from models import storage
 from models.engine import file_storage
 from models.amenity import Amenity
 from models.base_model import BaseModel
@@ -14,10 +18,6 @@ from models.place import Place
 from models.review import Review
 from models.state import State
 from models.user import User
-import json
-import os
-import pep8
-import unittest
 FileStorage = file_storage.FileStorage
 classes = {"Amenity": Amenity, "BaseModel": BaseModel, "City": City,
            "Place": Place, "Review": Review, "State": State, "User": User}


### PR DESCRIPTION
Implement MD5 hashing of `password` attributes in `User` class.
Achieved through override of `__setattr__` method to encode before setting.
Updated the `to_dict` method of `BaseModel` to not save passwords, except for `FileStorage`.
Scattering of bug fixes to unittests relying on old `password` usage.